### PR TITLE
Fixed hyperlink to pedestrians section for literature + codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Please cite our work if you found this useful:
 	- [Physics Systems with Interaction](#physics-systems-with-interaction)
 	- [Intelligent Vehicles & Traffic](#intelligent-vehicles-traffic)
 	- [Mobile Robots](#mobile-robots)
-	- [Pedestrians](#pedestrians)
+	- [Pedestrians](#pedestrians-1)
 	- [Vehicle-Pedestrians Interaction](#vehicle-pedestrians-interaction)
 	- [Sport Players](#sport-players)
 	- [Benchmark and Evaluation Metrics](#benchmark-and-evaluation-metrics)


### PR DESCRIPTION
This is an artificial change and you can just scroll down to the section, but the hyperlink to go to the pedestrians section under Literature and Codes wasn't correct.  It was linking to the dataset section instead.  This PR just fixes the hyperlink.